### PR TITLE
Removing Return call since Rent was already removed #29

### DIFF
--- a/AdvancedSharpAdbClient/Framebuffer.cs
+++ b/AdvancedSharpAdbClient/Framebuffer.cs
@@ -111,11 +111,6 @@ namespace AdvancedSharpAdbClient
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (Data != null)
-            {
-                ArrayPool<byte>.Shared.Return(Data, clearArray: false);
-            }
-
             headerData = null;
             headerInitialized = false;
             disposed = true;


### PR DESCRIPTION
At some point the rent call in rent shared buffer was removed but release was still in there which is causing issue #29 .