### PR TITLE
Make methods more thoroughly asynchronous

### DIFF
--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbClient.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbClient.cs
@@ -18,6 +18,9 @@ namespace AdvancedSharpAdbClient.Tests
 
         public Collection<string> ReceivedCommands { get; private set; } = new Collection<string>();
 
+        public Task InstallAsync(DeviceData device, Stream apk, CancellationToken ct = default, params string[] arguments) => 
+            throw new NotImplementedException();
+
         public EndPoint EndPoint { get; private set; }
 
         public string Pair(DnsEndPoint endpoint, string code) =>

--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyAdbSocket.cs
@@ -185,5 +185,31 @@ namespace AdvancedSharpAdbClient.Tests
                 }
             }
         }
+
+        public Task SendAsync(byte[] data, int length)
+        {
+            Send(data, length);
+            return Task.CompletedTask;
+        }
+
+        public Task SendAsync(byte[] data, int offset, int length)
+        {
+            Send(data, offset, length);
+            return Task.CompletedTask;
+        }
+
+        public Task SendAdbRequestAsync(string request)
+        {
+            SendAdbRequest(request);
+            return Task.CompletedTask;
+        }
+
+        public Task<AdbResponse> ReadAdbResponseAsync()
+        {
+            var response = ReadAdbResponse();
+            var tcs = new TaskCompletionSource<AdbResponse>();
+            tcs.SetResult(response);
+            return tcs.Task;
+        }
     }
 }

--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyTcpSocket.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyTcpSocket.cs
@@ -38,7 +38,10 @@ namespace AdvancedSharpAdbClient.Tests
 
         public Task<int> SendAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags)
         {
-            throw new NotImplementedException();
+            var result = Send(buffer, offset, size, socketFlags);
+            var tcs = new TaskCompletionSource<int>();
+            tcs.SetResult(result);
+            return tcs.Task;
         }
 
         public int Receive(byte[] buffer, int size, SocketFlags socketFlags) => InputStream.Read(buffer, 0, size);

--- a/AdvancedSharpAdbClient.Tests/Dummys/DummyTcpSocket.cs
+++ b/AdvancedSharpAdbClient.Tests/Dummys/DummyTcpSocket.cs
@@ -26,10 +26,20 @@ namespace AdvancedSharpAdbClient.Tests
         public void Close() => Connected = false;
 
         public void Connect(EndPoint endPoint) => Connected = true;
+        public Task ConnectAsync(EndPoint endPoint)
+        {
+            Connected = true;
+            return Task.CompletedTask;
+        }
 
         public void Dispose() => Connected = false;
 
         public Stream GetStream() => OutputStream;
+
+        public Task<int> SendAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        {
+            throw new NotImplementedException();
+        }
 
         public int Receive(byte[] buffer, int size, SocketFlags socketFlags) => InputStream.Read(buffer, 0, size);
 

--- a/AdvancedSharpAdbClient/AdbClient.Async.Net6.cs
+++ b/AdvancedSharpAdbClient/AdbClient.Async.Net6.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using AdvancedSharpAdbClient.Exceptions;
+using AdvancedSharpAdbClient.Logs;
+
+namespace AdvancedSharpAdbClient;
+
+#if NET6_0_OR_GREATER
+public partial class AdbClient
+{
+        /// <inheritdoc/>
+        public async Task<int> GetAdbVersionAsync(CancellationToken cancellationToken = default)
+        {
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync("host:version");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            string version = await socket.ReadStringAsync(cancellationToken);
+
+            return int.Parse(version, NumberStyles.HexNumber);
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<DeviceData>> GetDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync("host:devices-l");
+            await socket.ReadAdbResponseAsync();
+            string reply = await socket.ReadStringAsync(cancellationToken);
+
+            string[] data = reply.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            return data.Select(DeviceData.CreateFromAdbData).ToList();
+        }
+
+        /// <inheritdoc/>
+        public async Task<int> CreateReverseForwardAsync(DeviceData device, string remote, string local, bool allowRebind, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+
+            string rebind = allowRebind ? string.Empty : "norebind:";
+
+            await socket.SendAdbRequestAsync($"reverse:forward:{rebind}{remote};{local}");
+            _ = await socket.ReadAdbResponseAsync();
+            _ = await socket.ReadAdbResponseAsync();
+            string portString = await socket.ReadStringAsync(cancellationToken);
+
+            return portString != null && int.TryParse(portString, out int port) ? port : 0;
+        }
+
+        /// <inheritdoc/>
+        public async Task<int> CreateForwardAsync(DeviceData device, string local, string remote, bool allowRebind, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            string rebind = allowRebind ? string.Empty : "norebind:";
+
+            await socket.SendAdbRequestAsync($"host-serial:{device.Serial}:forward:{rebind}{local};{remote}");
+            _ = await socket.ReadAdbResponseAsync();
+            _ = await socket.ReadAdbResponseAsync();
+            string portString = await socket.ReadStringAsync(cancellationToken);
+
+            return portString != null && int.TryParse(portString, out int port) ? port : 0;
+        }
+        
+        /// <inheritdoc/>
+        public async Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            cancellationToken.Register(socket.Dispose);
+
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync($"shell:{command}");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+
+            try
+            {
+                using StreamReader reader = new(socket.GetShellStream(), encoding);
+                // Previously, we would loop while reader.Peek() >= 0. Turns out that this would
+                // break too soon in certain cases (about every 10 loops, so it appears to be a timing
+                // issue). Checking for reader.ReadLine() to return null appears to be much more robust
+                // -- one of the integration test fetches output 1000 times and found no truncations.
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    string line =
+                        await reader.ReadLineAsync().ConfigureAwait(false);
+                    
+                    if (line == null) { break; }
+
+                    receiver?.AddOutput(line);
+                }
+            }
+            catch (Exception e)
+            {
+                // If a cancellation was requested, this main loop is interrupted with an exception
+                // because the socket is closed. In that case, we don't need to throw a ShellCommandUnresponsiveException.
+                // In all other cases, something went wrong, and we want to report it to the user.
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    throw new ShellCommandUnresponsiveException(e);
+                }
+            }
+            finally
+            {
+                receiver?.Flush();
+            }
+        }
+                
+        /// <inheritdoc/>
+        public async Task InstallAsync(DeviceData device, Stream apk, CancellationToken ct = default, params string[] arguments)
+        {
+            EnsureDevice(device);
+
+            if (apk == null)
+            {
+                throw new ArgumentNullException(nameof(apk));
+            }
+
+            if (!apk.CanRead || !apk.CanSeek)
+            {
+                throw new ArgumentOutOfRangeException(nameof(apk), "The apk stream must be a readable and seekable stream");
+            }
+
+            StringBuilder requestBuilder = new();
+            _ = requestBuilder.Append("exec:cmd package 'install' ");
+
+            if (arguments != null)
+            {
+                foreach (string argument in arguments)
+                {
+                    _ = requestBuilder.Append(' ');
+                    _ = requestBuilder.Append(argument);
+                }
+            }
+
+            // add size parameter [required for streaming installs]
+            // do last to override any user specified value
+            _ = requestBuilder.Append($" -S {apk.Length}");
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+
+            await socket.SendAdbRequestAsync(requestBuilder.ToString());
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+
+            byte[] buffer = new byte[32 * 1024];
+            int read = 0;
+
+            while ((read = await apk.ReadAsync(buffer, 0, buffer.Length, ct)) > 0)
+            {
+                await socket.SendAsync(buffer, read);
+            }
+
+            read = await socket.ReadAsync(buffer, buffer.Length, ct);
+            string value = Encoding.UTF8.GetString(buffer, 0, read);
+
+            if (!value.Contains("Success"))
+            {
+                throw new AdbException(value);
+            }
+        }
+        
+        /// <inheritdoc/>
+        public async Task SendKeyEventAsync(DeviceData device, string key)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input keyevent {0}", key));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+
+            if (result.ToUpper().Contains("ERROR"))
+            {
+                throw new InvalidKeyEventException("KeyEvent is invalid");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task SendTextAsync(DeviceData device, string text)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input text {0}", text));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+            if (result.ToUpper().Contains("ERROR"))
+            {
+                throw new InvalidTextException();
+            }
+        }
+        
+        /// <inheritdoc/>
+        public async Task RunLogServiceAsync(DeviceData device, Action<LogEntry> messageSink, CancellationToken cancellationToken = default, params LogId[] logNames)
+        {
+            if (messageSink == null)
+            {
+                throw new ArgumentNullException(nameof(messageSink));
+            }
+
+            EnsureDevice(device);
+
+            // The 'log' service has been deprecated, see
+            // https://android.googlesource.com/platform/system/core/+/7aa39a7b199bb9803d3fd47246ee9530b4a96177
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+
+            StringBuilder request = new();
+            request.Append("shell:logcat -B");
+
+            foreach (LogId logName in logNames)
+            {
+                request.Append($" -b {logName.ToString().ToLowerInvariant()}");
+            }
+
+            await socket.SendAdbRequestAsync(request.ToString());
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+
+            await using Stream stream = socket.GetShellStream();
+            LogReader reader = new(stream);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                LogEntry entry = null;
+
+                try
+                {
+                    entry = await reader.ReadEntry(cancellationToken).ConfigureAwait(false);
+                }
+                catch (EndOfStreamException)
+                {
+                    // This indicates the end of the stream; the entry will remain null.
+                }
+
+                if (entry != null)
+                {
+                    messageSink(entry);
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> PairAsync(DnsEndPoint endpoint, string code, CancellationToken cancellationToken = default)
+        {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync($"host:pair:{code}:{endpoint.Host}:{endpoint.Port}");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            string results = await socket.ReadStringAsync(cancellationToken);
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> ConnectAsync(DnsEndPoint endpoint, CancellationToken cancellationToken = default)
+        {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync($"host:connect:{endpoint.Host}:{endpoint.Port}");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            string results = await socket.ReadStringAsync(cancellationToken);
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> DisconnectAsync(DnsEndPoint endpoint, CancellationToken cancellationToken = default)
+        {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync($"host:disconnect:{endpoint.Host}:{endpoint.Port}");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            string results = await socket.ReadStringAsync(cancellationToken);
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<string>> GetFeatureSetAsync(DeviceData device, CancellationToken cancellationToken = default)
+        {
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync($"host-serial:{device.Serial}:features");
+
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            string features = await socket.ReadStringAsync(cancellationToken);
+
+            List<string> featureList = features.Split(new char[] { '\n', ',' }).ToList();
+            return featureList;
+        }
+
+        /// <inheritdoc/>
+        public async Task<XmlDocument> DumpScreenAsync(DeviceData device)
+        {
+            XmlDocument doc = new();
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync("shell:uiautomator dump /dev/tty");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string xmlString = await reader.ReadToEndAsync();
+
+            xmlString = xmlString.Replace("Events injected: 1\r\n", "").Replace("UI hierchary dumped to: /dev/tty", "").Trim();
+            if (xmlString != "" && !xmlString.StartsWith("ERROR"))
+            {
+                doc.LoadXml(xmlString);
+                return doc;
+            }
+            return null;
+        }
+        
+        /// <inheritdoc/>
+        public async Task ClickAsync(DeviceData device, Cords cords)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input tap {0} {1}", cords.X, cords.Y));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+
+            if (result.ToUpper().Contains("ERROR")) // error or ERROR
+            {
+                throw new ElementNotFoundException("Coordinates of element is invalid");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task ClickAsync(DeviceData device, int x, int y)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input tap {0} {1}", x, y));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+
+            if (result.ToUpper().Contains("ERROR"))
+            {
+                throw new ElementNotFoundException("Coordinates of element is invalid");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task SwipeAsync(DeviceData device, Element first, Element second, long speed)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input swipe {0} {1} {2} {3} {4}", first.Cords.X, first.Cords.Y, second.Cords.X, second.Cords.Y, speed));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+
+            if (result.ToUpper().Contains("ERROR"))
+            {
+                throw new ElementNotFoundException("Coordinates of element is invalid");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task SwipeAsync(DeviceData device, int x1, int y1, int x2, int y2, long speed)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+            await socket.SendAdbRequestAsync(string.Format("shell:input swipe {0} {1} {2} {3} {4}", x1, y1, x2, y2, speed));
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+            using StreamReader reader = new(socket.GetShellStream(), Encoding);
+            string result = await reader.ReadToEndAsync();
+
+            if (result.ToUpper().Contains("ERROR"))
+            {
+                throw new ElementNotFoundException("Coordinates of element is invalid");
+            }
+        }
+        
+        /// <inheritdoc/>
+        public async Task<IEnumerable<ForwardData>> ListForwardAsync(DeviceData device, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            await socket.SendAdbRequestAsync($"host-serial:{device.Serial}:list-forward");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+
+            string data = await socket.ReadStringAsync(cancellationToken);
+
+            string[] parts = data.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            return parts.Select(ForwardData.FromString);
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<ForwardData>> ListReverseForwardAsync(DeviceData device, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using IAdbSocket socket = adbSocketFactory(EndPoint);
+            socket.SetDevice(device);
+
+            await socket.SendAdbRequestAsync($"reverse:list-forward");
+            AdbResponse response = await socket.ReadAdbResponseAsync();
+
+            string data = await socket.ReadStringAsync(cancellationToken);
+
+            string[] parts = data.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            return parts.Select(ForwardData.FromString);
+        }
+}
+#endif

--- a/AdvancedSharpAdbClient/AdbClient.Async.cs
+++ b/AdvancedSharpAdbClient/AdbClient.Async.cs
@@ -24,6 +24,7 @@ namespace AdvancedSharpAdbClient
 {
     public partial class AdbClient
     {
+#if !NET6_0_OR_GREATER 
         /// <inheritdoc/>
         public async Task<int> GetAdbVersionAsync(CancellationToken cancellationToken = default)
         {
@@ -83,10 +84,6 @@ namespace AdvancedSharpAdbClient
         }
 
         /// <inheritdoc/>
-        public Task<int> CreateForwardAsync(DeviceData device, ForwardSpec local, ForwardSpec remote, bool allowRebind, CancellationToken cancellationToken = default) =>
-            CreateForwardAsync(device, local?.ToString(), remote?.ToString(), allowRebind, cancellationToken);
-
-        /// <inheritdoc/>
         public async Task<IEnumerable<ForwardData>> ListForwardAsync(DeviceData device, CancellationToken cancellationToken = default)
         {
             EnsureDevice(device);
@@ -119,10 +116,6 @@ namespace AdvancedSharpAdbClient
 
             return parts.Select(ForwardData.FromString);
         }
-
-        /// <inheritdoc/>
-        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken = default) =>
-            ExecuteRemoteCommandAsync(command, device, receiver, Encoding, cancellationToken);
 
         /// <inheritdoc/>
         public async Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding, CancellationToken cancellationToken = default)
@@ -171,21 +164,6 @@ namespace AdvancedSharpAdbClient
             {
                 receiver?.Flush();
             }
-        }
-
-        /// <inheritdoc/>
-#if NET
-        [SupportedOSPlatform("windows")]
-#endif
-        public async Task<Image> GetFrameBufferAsync(DeviceData device, CancellationToken cancellationToken = default)
-        {
-            EnsureDevice(device);
-
-            using Framebuffer framebuffer = CreateRefreshableFramebuffer(device);
-            await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
-
-            // Convert the framebuffer to an image, and return that.
-            return framebuffer.ToImage();
         }
 
         /// <inheritdoc/>
@@ -405,6 +383,30 @@ namespace AdvancedSharpAdbClient
                 throw new ElementNotFoundException("Coordinates of element is invalid");
             }
         }
+#endif
+        
+        /// <inheritdoc/>
+#if NET
+        [SupportedOSPlatform("windows")]
+#endif
+        public async Task<Image> GetFrameBufferAsync(DeviceData device, CancellationToken cancellationToken = default)
+        {
+            EnsureDevice(device);
+
+            using Framebuffer framebuffer = CreateRefreshableFramebuffer(device);
+            await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
+
+            // Convert the framebuffer to an image, and return that.
+            return framebuffer.ToImage();
+        }
+        
+        /// <inheritdoc/>
+        public Task<int> CreateForwardAsync(DeviceData device, ForwardSpec local, ForwardSpec remote, bool allowRebind, CancellationToken cancellationToken = default) =>
+            CreateForwardAsync(device, local?.ToString(), remote?.ToString(), allowRebind, cancellationToken);
+
+        /// <inheritdoc/>
+        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken = default) =>
+            ExecuteRemoteCommandAsync(command, device, receiver, Encoding, cancellationToken);
 
         /// <inheritdoc/>
         public async Task<Element> FindElementAsync(DeviceData device, string xpath, CancellationToken cancellationToken = default)
@@ -495,6 +497,7 @@ namespace AdvancedSharpAdbClient
             return null;
         }
 
+#if !NET6_0_OR_GREATER
         /// <inheritdoc/>
         public async Task SendKeyEventAsync(DeviceData device, string key)
         {
@@ -536,11 +539,11 @@ namespace AdvancedSharpAdbClient
                 throw new InvalidTextException();
             }
         }
-
+#endif
         /// <inheritdoc/>
         public async Task ClearInputAsync(DeviceData device, int charcount, CancellationToken cancellationToken = default)
         {
-            SendKeyEvent(device, "KEYCODE_MOVE_END");
+            await SendKeyEventAsync(device, "KEYCODE_MOVE_END");
             await ExecuteRemoteCommandAsync("input keyevent " + Utilities.Join(" ", Enumerable.Repeat("KEYCODE_DEL ", charcount)), device, null, cancellationToken);
         }
 

--- a/AdvancedSharpAdbClient/AdbSocket.Async.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.Async.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using AdvancedSharpAdbClient.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace AdvancedSharpAdbClient
+{
+    public partial class AdbSocket
+    {
+        /// <inheritdoc/>
+        public virtual async Task<AdbResponse> ReadAdbResponseAsync()
+        {
+            AdbResponse response = await ReadAdbResponseInnerAsync();
+
+            if (!response.IOSuccess || !response.Okay)
+            {
+                socket.Dispose();
+                throw new AdbException($"An error occurred while reading a response from ADB: {response.Message}", response);
+            }
+
+            return response;
+        }
+        
+        /// <summary>
+        /// Reads the response from ADB after a command.
+        /// </summary>
+        /// <returns>A <see cref="AdbResponse"/> that represents the response received from ADB.</returns>
+        protected async Task<AdbResponse> ReadAdbResponseInnerAsync()
+        {
+            AdbResponse resp = new();
+
+            byte[] reply = new byte[4];
+            await ReadAsync(reply);
+
+            resp.IOSuccess = true;
+
+            resp.Okay = IsOkay(reply);
+
+            if (!resp.Okay)
+            {
+                string message = await ReadStringAsync();
+                resp.Message = message;
+#if HAS_LOGGER
+                logger.LogError("Got reply '{0}', diag='{1}'", ReplyToString(reply), resp.Message);
+#endif
+            }
+
+            return resp;
+        }
+
+        /// <inheritdoc/>
+        public virtual async Task<int> ReadAsync(byte[] data, int length, CancellationToken cancellationToken = default)
+        {
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (data.Length < length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(data));
+            }
+
+            int count = -1;
+            int totalRead = 0;
+
+            while (count != 0 && totalRead < length)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    int left = length - totalRead;
+                    int buflen = left < ReceiveBufferSize ? left : ReceiveBufferSize;
+
+                    count = await socket.ReceiveAsync(data, totalRead, buflen, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+
+                    if (count < 0)
+                    {
+#if HAS_LOGGER
+                        logger.LogError("read: channel EOF");
+#endif
+                        throw new AdbException("EOF");
+                    }
+                    else if (count == 0)
+                    {
+#if HAS_LOGGER
+                        logger.LogInformation("DONE with Read");
+#endif
+                    }
+                    else
+                    {
+                        totalRead += count;
+                    }
+                }
+                catch (SocketException ex)
+                {
+                    throw new AdbException($"An error occurred while receiving data from the adb server: {ex.Message}.", ex);
+                }
+            }
+
+            return totalRead;
+        }
+            
+#if NET6_0_OR_GREATER
+        
+        /// <summary>
+        /// Write until all data in "data" is written or the connection fails or times out.
+        /// </summary>
+        /// <param name="data">The data to send.</param>
+        /// <returns>Returns <see langword="true"/> if all data was written; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>This uses the default time out value.</remarks>
+        protected async Task<bool> WriteAsync(byte[] data)
+        {
+            try
+            {
+                await SendAsync(data, -1);
+            }
+#if HAS_LOGGER
+            catch (IOException e)
+            {
+                logger.LogError(e, e.Message);
+#else
+            catch (IOException)
+            {
+#endif
+                return false;
+            }
+
+            return true;
+        }
+        
+        /// <inheritdoc/>
+        public virtual async Task SendAdbRequestAsync(string request)
+        {
+            byte[] data = AdbClient.FormAdbRequest(request);
+
+            if (!await WriteAsync(data))
+            {
+                throw new IOException($"Failed sending the request '{request}' to ADB");
+            }
+        }
+        
+        /// <inheritdoc/>
+        public virtual Task SendAsync(byte[] data, int length) => SendAsync(data, 0, length);
+
+        /// <inheritdoc/>
+        public virtual async Task SendAsync(byte[] data, int offset, int length)
+        {
+            try
+            {
+                int count = await socket.SendAsync(data, offset, length != -1 ? length : data.Length, SocketFlags.None);
+                if (count < 0)
+                {
+                    throw new AdbException("channel EOF");
+                }
+            }
+            catch (SocketException ex)
+            {
+#if HAS_LOGGER
+                logger.LogError(ex, ex.Message);
+#endif
+                throw ex;
+            }
+        }
+#endif
+    }
+}

--- a/AdvancedSharpAdbClient/AdbSocket.cs
+++ b/AdvancedSharpAdbClient/AdbSocket.cs
@@ -37,7 +37,7 @@ namespace AdvancedSharpAdbClient
     /// <see href="https://android.googlesource.com/platform/system/core/+/master/adb/OVERVIEW.TXT"/>.
     /// </para>
     /// </summary>
-    public class AdbSocket : IAdbSocket, IDisposable
+    public partial class AdbSocket : IAdbSocket, IDisposable
     {
         /// <summary>
         /// The underlying TCP socket that manages the connection with the ADB server.
@@ -282,65 +282,6 @@ namespace AdvancedSharpAdbClient
 #endif
                 throw sex;
             }
-        }
-
-        /// <inheritdoc/>
-        public virtual async Task<int> ReadAsync(byte[] data, int length, CancellationToken cancellationToken = default)
-        {
-            if (length < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(length));
-            }
-
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
-
-            if (data.Length < length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(data));
-            }
-
-            int count = -1;
-            int totalRead = 0;
-
-            while (count != 0 && totalRead < length)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    int left = length - totalRead;
-                    int buflen = left < ReceiveBufferSize ? left : ReceiveBufferSize;
-
-                    count = await socket.ReceiveAsync(data, totalRead, buflen, SocketFlags.None, cancellationToken).ConfigureAwait(false);
-
-                    if (count < 0)
-                    {
-#if HAS_LOGGER
-                        logger.LogError("read: channel EOF");
-#endif
-                        throw new AdbException("EOF");
-                    }
-                    else if (count == 0)
-                    {
-#if HAS_LOGGER
-                        logger.LogInformation("DONE with Read");
-#endif
-                    }
-                    else
-                    {
-                        totalRead += count;
-                    }
-                }
-                catch (SocketException ex)
-                {
-                    throw new AdbException($"An error occurred while receiving data from the adb server: {ex.Message}.", ex);
-                }
-            }
-
-            return totalRead;
         }
 
         /// <inheritdoc/>

--- a/AdvancedSharpAdbClient/Element.cs
+++ b/AdvancedSharpAdbClient/Element.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace AdvancedSharpAdbClient
 {
@@ -50,6 +51,11 @@ namespace AdvancedSharpAdbClient
         /// Clicks on this coordinates.
         /// </summary>
         public void Click() => Client.Click(Device, Cords);
+        
+        /// <summary>
+        /// Clicks on this coordinates.
+        /// </summary>
+        public async Task ClickAsync() => await Client.ClickAsync(Device, Cords);
 
         /// <summary>
         /// Send text to device. Doesn't support Russian.

--- a/AdvancedSharpAdbClient/Interfaces/IAdbClient.Async.cs
+++ b/AdvancedSharpAdbClient/Interfaces/IAdbClient.Async.cs
@@ -7,6 +7,7 @@ using AdvancedSharpAdbClient.Logs;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -369,5 +370,16 @@ namespace AdvancedSharpAdbClient
         /// <param name="device"></param>
         /// <returns>A <see cref="Task"/> which represents the asynchronous operation.</returns>
         Task HomeBtnAsync(DeviceData device);
+        
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Asynchronously installs an Android application on an device.
+        /// </summary>
+        /// <param name="device">The device on which to install the application.</param>
+        /// <param name="apk">A <see cref="Stream"/> which represents the application to install.</param>
+        /// <param name="cancellationToken">A cancellation token</param>
+        /// <param name="arguments">The arguments to pass to <c>adb install</c>.</param>
+        Task InstallAsync(DeviceData device, Stream apk, CancellationToken cancellationToken, params string[] arguments);
+#endif
     }
 }

--- a/AdvancedSharpAdbClient/Interfaces/IAdbSocket.cs
+++ b/AdvancedSharpAdbClient/Interfaces/IAdbSocket.cs
@@ -159,5 +159,36 @@ namespace AdvancedSharpAdbClient
         /// <param name="device">The device to which to connect.</param>
         /// <remarks>If <paramref name="device"/> is <see langword="null"/>, this method does nothing.</remarks>
         void SetDevice(DeviceData device);
+        
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Sends the specified number of bytes of data to a <see cref="IAdbSocket"/>,
+        /// </summary>
+        /// <param name="data">A <see cref="byte"/> array that acts as a buffer, containing the data to send.</param>
+        /// <param name="length">The number of bytes to send.</param>
+        Task SendAsync(byte[] data, int length);
+
+        /// <summary>
+        /// Sends the specified number of bytes of data to a <see cref="IAdbSocket"/>,
+        /// </summary>
+        /// <param name="data">A <see cref="byte"/> array that acts as a buffer, containing the data to send.</param>
+        /// <param name="offset">The index of the first byte in the array to send.</param>
+        /// <param name="length">The number of bytes to send.</param>
+        Task SendAsync(byte[] data, int offset, int length);
+        
+        /// <summary>
+        /// Asynchronously sends a request to the Android Debug Bridge.To read the response, call
+        /// <see cref="ReadAdbResponseAsync()"/>.
+        /// </summary>
+        /// <param name="request">The request to send.</param>
+        Task SendAdbRequestAsync(string request);
+        
+        /// <summary>
+        /// Asynchronously receives an <see cref="AdbResponse"/> message, and throws an error
+        /// if the message does not indicate success.
+        /// </summary>
+        /// <returns>A <see cref="AdbResponse"/> object that represents the response from the Android Debug Bridge.</returns>
+        Task<AdbResponse> ReadAdbResponseAsync();
+#endif
     }
 }

--- a/AdvancedSharpAdbClient/Interfaces/ITcpSocket.cs
+++ b/AdvancedSharpAdbClient/Interfaces/ITcpSocket.cs
@@ -81,5 +81,19 @@ namespace AdvancedSharpAdbClient
         /// </summary>
         /// <returns>The underlying stream.</returns>
         Stream GetStream();
+        
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Asynchronously sends the specified number of bytes of data to a connected
+        /// <see cref="ITcpSocket"/>, starting at the specified <paramref name="offset"/>,
+        /// and using the specified <paramref name="socketFlags"/>.
+        /// </summary>
+        /// <param name="buffer">An array of type Byte that contains the data to be sent.</param>
+        /// <param name="offset">The position in the data buffer at which to begin sending data.</param>
+        /// <param name="size">The number of bytes to send.</param>
+        /// <param name="socketFlags">A bitwise combination of the SocketFlags values.</param>
+        /// <returns>The number of bytes sent to the Socket.</returns>
+        public Task<int> SendAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags);
+#endif
     }
 }

--- a/AdvancedSharpAdbClient/TcpSocket.cs
+++ b/AdvancedSharpAdbClient/TcpSocket.cs
@@ -79,9 +79,19 @@ namespace AdvancedSharpAdbClient
         /// <inheritdoc/>
         public int Receive(byte[] buffer, int offset, SocketFlags socketFlags) =>
             socket.Receive(buffer, offset, socketFlags);
-
+        
+#if NET6_0_OR_GREATER
+        /// <inheritdoc/>
+        public async Task<int> SendAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags) =>
+            await socket.SendAsync(buffer.AsMemory().Slice(offset, size), socketFlags);
+        
+        /// <inheritdoc/>
+        public async Task<int> ReceiveAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags, CancellationToken cancellationToken = default) => 
+            await socket.ReceiveAsync(buffer.AsMemory().Slice(offset, size), socketFlags, cancellationToken);
+#else
         /// <inheritdoc/>
         public Task<int> ReceiveAsync(byte[] buffer, int offset, int size, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
             socket.ReceiveAsync(buffer, offset, size, socketFlags, cancellationToken);
+#endif
     }
 }


### PR DESCRIPTION
I used the Socket.SendAsync and Socket.ReceiveAsync methods in .NET6+ to make a lot of the code more "async all the way down". I put them behind ``` #if NET6_0_OR_GREATER ``` directives and tried to integrate the new methods as cleanly as possible.

Also added InstallAsync method that uses the new async methods.