### PR TITLE
Add string extension methods for null or empty checks and their unit tests.

### DIFF
--- a/AdvancedSharpAdbClient.Tests/Extensions/StringExtensionsTests.cs
+++ b/AdvancedSharpAdbClient.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿using AdvancedSharpAdbClient.Extensions;
+using Xunit;
+
+namespace StringExtensions.Tests
+{
+    public class StringExtensionsTests
+    {
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData("Hello", true)]
+        public void IsNotNullOrEmpty_ShouldReturnCorrectResult(string value, bool expected)
+        {
+            // Arrange
+            // Nothing to arrange
+
+            // Act
+            var result = value.IsNotNullOrEmpty();
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData("Hello", true)]
+        [InlineData(" Hello ", true)]
+        public void IsNotNullOrWhiteSpace_ShouldReturnCorrectResult(string value, bool expected)
+        {
+            // Arrange
+            // Nothing to arrange
+
+            // Act
+            var result = value.IsNotNullOrWhiteSpace();
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/AdvancedSharpAdbClient/DeviceCommands/PackageManager.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/PackageManager.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using AdvancedSharpAdbClient.Exceptions;
+using AdvancedSharpAdbClient.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -183,7 +184,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
 
             InstallProgressChanged?.Invoke(this, 95);
 
-            if (!string.IsNullOrEmpty(receiver.ErrorMessage))
+            if (receiver.ErrorMessage.IsNotNullOrEmpty())
             {
                 throw new PackageInstallationException(receiver.ErrorMessage);
             }
@@ -294,7 +295,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
 
             InstallProgressChanged?.Invoke(this, 95);
 
-            if (!string.IsNullOrEmpty(receiver.ErrorMessage))
+            if (receiver.ErrorMessage.IsNotNullOrEmpty())
             {
                 throw new PackageInstallationException(receiver.ErrorMessage);
             }
@@ -334,7 +335,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
 
             InstallProgressChanged?.Invoke(this, 95);
 
-            if (!string.IsNullOrEmpty(receiver.ErrorMessage))
+            if (receiver.ErrorMessage.IsNotNullOrEmpty())
             {
                 throw new PackageInstallationException(receiver.ErrorMessage);
             }
@@ -350,7 +351,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
 
             InstallReceiver receiver = new();
             client.ExecuteShellCommand(Device, $"pm uninstall {packageName}", receiver);
-            if (!string.IsNullOrEmpty(receiver.ErrorMessage))
+            if (receiver.ErrorMessage.IsNotNullOrEmpty())
             {
                 throw new PackageInstallationException(receiver.ErrorMessage);
             }
@@ -467,7 +468,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
 
             InstallReceiver receiver = new();
             string reinstallSwitch = reinstall ? " -r" : string.Empty;
-            string addon = packageName.IsNullOrWhiteSpace() ? string.Empty : $" -p {packageName}";
+            string addon = packageName.IsNotNullOrEmpty() ? string.Empty : $" -p {packageName}";
 
             string cmd = $"pm install-create{reinstallSwitch}{addon}";
             client.ExecuteShellCommand(Device, cmd, receiver);
@@ -497,7 +498,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
             InstallReceiver receiver = new();
             client.ExecuteShellCommand(Device, $"pm install-write {session} {apkname}.apk \"{path}\"", receiver);
 
-            if (!string.IsNullOrEmpty(receiver.ErrorMessage))
+            if (receiver.ErrorMessage.IsNotNullOrEmpty())
             {
                 throw new PackageInstallationException(receiver.ErrorMessage);
             }

--- a/AdvancedSharpAdbClient/Extensions/StringExtensions.cs
+++ b/AdvancedSharpAdbClient/Extensions/StringExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AdvancedSharpAdbClient.Extensions
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="String"/> class.
+    /// </summary>
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Checks if a string is not null or empty.
+        /// </summary>
+        /// <param name="value">The string to check.</param>
+        /// <returns>True if the string is not null or empty, false otherwise.</returns>
+        public static bool IsNotNullOrEmpty(this string value)
+        {
+            return !string.IsNullOrEmpty(value);
+        }
+
+        /// <summary>
+        /// Checks if a string is not null or whitespace.
+        /// </summary>
+        /// <param name="value">The string to check.</param>
+        /// <returns>True if the string is not null or whitespace, false otherwise.</returns>
+        public static bool IsNotNullOrWhiteSpace(this string value)
+        {
+            return !string.IsNullOrWhiteSpace(value);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds two new extension methods for strings: IsNotNullOrEmpty and IsNotNullOrWhiteSpace. These methods extend the string type and return a boolean value indicating whether the string is not null or empty or whitespace. They can be useful for validating user input or checking string conditions.

The pull request also adds unit tests for these methods using Xunit. The tests cover various cases of null, empty, whitespace and non-empty strings. The tests use the [Theory] and [InlineData] attributes to provide multiple test data.