### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/AdvancedSharpAdbClient.Tests/AdbServerTests.Async.cs
+++ b/AdvancedSharpAdbClient.Tests/AdbServerTests.Async.cs
@@ -1,5 +1,6 @@
 ﻿using AdvancedSharpAdbClient.Exceptions;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using System;
 using System.Net.Sockets;
 using System.Threading;
@@ -12,11 +13,10 @@ namespace AdvancedSharpAdbClient.Tests
         [Fact]
         public async void GetStatusAsyncNotRunningTest()
         {
-            Mock<IAdbClient> adbClientMock = new();
-            adbClientMock.Setup(c => c.GetAdbVersionAsync(It.IsAny<CancellationToken>()))
-                .Throws(new AggregateException(new SocketException(AdbServer.ConnectionRefused)));
+            IAdbClient adbClientMock = Substitute.For<IAdbClient>();
+            adbClientMock.GetAdbVersionAsync(Arg.Any<CancellationToken>()).Throws(new AggregateException(new SocketException(AdbServer.ConnectionRefused)));
 
-            AdbServer adbServer = new(adbClientMock.Object, adbCommandLineClientFactory);
+            AdbServer adbServer = new(adbClientMock, adbCommandLineClientFactory);
 
             AdbServerStatus status = await adbServer.GetStatusAsync();
             Assert.False(status.IsRunning);

--- a/AdvancedSharpAdbClient.Tests/AdbServerTests.cs
+++ b/AdvancedSharpAdbClient.Tests/AdbServerTests.cs
@@ -1,5 +1,6 @@
 ﻿using AdvancedSharpAdbClient.Exceptions;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using System;
 using System.Net;
 using System.Net.Sockets;
@@ -36,11 +37,10 @@ namespace AdvancedSharpAdbClient.Tests
         [Fact]
         public void GetStatusNotRunningTest()
         {
-            Mock<IAdbClient> adbClientMock = new();
-            adbClientMock.Setup(c => c.GetAdbVersion())
-                .Throws(new SocketException(AdbServer.ConnectionRefused));
+            IAdbClient adbClientMock = Substitute.For<IAdbClient>();
+            adbClientMock.GetAdbVersion().Throws(new SocketException(AdbServer.ConnectionRefused));
 
-            AdbServer adbServer = new(adbClientMock.Object, adbCommandLineClientFactory);
+            AdbServer adbServer = new(adbClientMock, adbCommandLineClientFactory);
 
             AdbServerStatus status = adbServer.GetStatus();
             Assert.False(status.IsRunning);

--- a/AdvancedSharpAdbClient.Tests/AdvancedSharpAdbClient.Tests.csproj
+++ b/AdvancedSharpAdbClient.Tests/AdvancedSharpAdbClient.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AdvancedSharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.Async.cs
+++ b/AdvancedSharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.Async.cs
@@ -1,5 +1,5 @@
 ﻿using AdvancedSharpAdbClient.Tests;
-using Moq;
+using NSubstitute;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -17,16 +17,16 @@ namespace AdvancedSharpAdbClient.DeviceCommands.Tests
             TaskCompletionSource<FileStatistics> tcs = new();
             tcs.SetResult(stats);
 
-            Mock<IAdbClient> client = new();
-            Mock<ISyncService> mock = new();
-            mock.Setup(m => m.StatAsync("/test", It.IsAny<CancellationToken>())).Returns(tcs.Task);
+            IAdbClient client = Substitute.For<IAdbClient>();
+            ISyncService mock = Substitute.For<ISyncService>();
+            mock.StatAsync("/test", Arg.Any<CancellationToken>()).Returns(tcs.Task);
 
             lock (FactoriesTests.locker)
             {
-                Factories.SyncServiceFactory = (c, d) => mock.Object;
+                Factories.SyncServiceFactory = (c, d) => mock;
 
                 DeviceData device = new();
-                Assert.Equal(tcs.Task.Result, client.Object.StatAsync(device, "/test").Result);
+                Assert.Equal(tcs.Task.Result, client.StatAsync(device, "/test").Result);
 
                 Factories.Reset();
             }

--- a/AdvancedSharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
+++ b/AdvancedSharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
@@ -1,5 +1,5 @@
 ﻿using AdvancedSharpAdbClient.Tests;
-using Moq;
+using NSubstitute;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -16,16 +16,16 @@ namespace AdvancedSharpAdbClient.DeviceCommands.Tests
         {
             FileStatistics stats = new();
 
-            Mock<IAdbClient> client = new();
-            Mock<ISyncService> mock = new();
-            mock.Setup(m => m.Stat("/test")).Returns(stats);
+            IAdbClient client = Substitute.For<IAdbClient>();
+            ISyncService mock = Substitute.For<ISyncService>();
+            mock.Stat("/test").Returns(stats);
 
             lock (FactoriesTests.locker)
             {
-                Factories.SyncServiceFactory = (c, d) => mock.Object;
+                Factories.SyncServiceFactory = (c, d) => mock;
 
                 DeviceData device = new();
-                Assert.Equal(stats, client.Object.Stat(device, "/test"));
+                Assert.Equal(stats, client.Stat(device, "/test"));
 
                 Factories.Reset();
             }

--- a/AdvancedSharpAdbClient.Tests/DeviceCommands/PackageManagerTests.cs
+++ b/AdvancedSharpAdbClient.Tests/DeviceCommands/PackageManagerTests.cs
@@ -1,5 +1,5 @@
 ﻿using AdvancedSharpAdbClient.Tests;
-using Moq;
+using NSubstitute;
 using System;
 using System.IO;
 using Xunit;
@@ -14,7 +14,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands.Tests
         {
             _ = Assert.Throws<ArgumentNullException>(() => new PackageManager(null, null));
             _ = Assert.Throws<ArgumentNullException>(() => new PackageManager(null, new DeviceData()));
-            _ = Assert.Throws<ArgumentNullException>(() => new PackageManager(Mock.Of<IAdbClient>(), null));
+            _ = Assert.Throws<ArgumentNullException>(() => new PackageManager(Substitute.For<IAdbClient>(), null));
         }
 
         [Theory]

--- a/AdvancedSharpAdbClient.Tests/Extensions/AdbCommandLineClientExtensionsTests.cs
+++ b/AdvancedSharpAdbClient.Tests/Extensions/AdbCommandLineClientExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+﻿using NSubstitute;
 using System;
 using System.IO;
 using Xunit;
@@ -17,10 +17,10 @@ namespace AdvancedSharpAdbClient.Tests
         [Fact]
         public void EnsureIsValidAdbFileInvalidFileTest()
         {
-            Mock<IAdbCommandLineClient> clientMock = new();
-            clientMock.Setup(c => c.IsValidAdbFile(It.IsAny<string>())).Returns(false);
+            IAdbCommandLineClient clientMock = Substitute.For<IAdbCommandLineClient>();
+            clientMock.IsValidAdbFile(Arg.Any<string>()).Returns(false);
 
-            IAdbCommandLineClient client = clientMock.Object;
+            IAdbCommandLineClient client = clientMock;
 
             _ = Assert.Throws<FileNotFoundException>(() => client.EnsureIsValidAdbFile("xyz.exe"));
         }


### PR DESCRIPTION
This PR replaces Moq due to privacy and data exfiltration issues. See https://github.com/moq/moq/issues/1372 for original discussion.