### PR TITLE
Fixed "Doesn't support Russian" to "Doesn't support Unicode"

### DIFF
--- a/AdvancedSharpAdbClient/DeviceCommands/DeviceClient.Async.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/DeviceClient.Async.cs
@@ -442,7 +442,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
         }
 
         /// <summary>
-        /// Send text to device asynchronously. Doesn't support Russian.
+        /// Send text to device asynchronously. Doesn't support Unicode.
         /// </summary>
         /// <param name="text">The text to send.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.</param>

--- a/AdvancedSharpAdbClient/DeviceCommands/DeviceClient.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/DeviceClient.cs
@@ -382,7 +382,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
         }
 
         /// <summary>
-        /// Send text to device. Doesn't support Russian.
+        /// Send text to device. Doesn't support Unicode.
         /// </summary>
         /// <param name="text">The text to send.</param>
         public void SendText(string text)

--- a/AdvancedSharpAdbClient/DeviceCommands/DeviceExtensions.Async.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/DeviceExtensions.Async.cs
@@ -149,7 +149,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
             new DeviceClient(client, device).SendKeyEventAsync(key, cancellationToken);
 
         /// <summary>
-        /// Asynchronously send text to device. Doesn't support Russian.
+        /// Asynchronously send text to device. Doesn't support Unicode.
         /// </summary>
         /// <param name="client">The <see cref="IAdbClient"/> to use when executing the command.</param>
         /// <param name="device">The device on which to run the command.</param>

--- a/AdvancedSharpAdbClient/DeviceCommands/DeviceExtensions.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/DeviceExtensions.cs
@@ -122,7 +122,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
             new DeviceClient(client, device).SendKeyEvent(key);
 
         /// <summary>
-        /// Send text to device. Doesn't support Russian.
+        /// Send text to device. Doesn't support Unicode.
         /// </summary>
         /// <param name="client">An instance of a class that implements the <see cref="IAdbClient"/> interface.</param>
         /// <param name="device">The device on which to clear the input text.</param>

--- a/AdvancedSharpAdbClient/DeviceCommands/Models/Element.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/Models/Element.cs
@@ -252,7 +252,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands.Models
         }
 
         /// <summary>
-        /// Send text to device. Doesn't support Russian.
+        /// Send text to device. Doesn't support Unicode.
         /// </summary>
         /// <param name="text">The text to send.</param>
         public void SendText(string text)
@@ -313,7 +313,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands.Models
         }
 
         /// <summary>
-        /// Asynchronously send text to device. Doesn't support Russian.
+        /// Asynchronously send text to device. Doesn't support Unicode.
         /// </summary>
         /// <param name="text">The text to send.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.</param>


### PR DESCRIPTION
Found it strange that only Russian is not supported.
Checked it - actually any Unicode language (or character) is not supported.