### PR TITLE
fix(package-manager): propagate progress callback to PushAsync for detailed upload progress

### DIFF
--- a/AdvancedSharpAdbClient/DeviceCommands/PackageManager.Async.cs
+++ b/AdvancedSharpAdbClient/DeviceCommands/PackageManager.Async.cs
@@ -611,7 +611,7 @@ namespace AdvancedSharpAdbClient.DeviceCommands
                     Action<SyncProgressChangedEventArgs>? progress = callback == null ? null : args => callback.Invoke(localFilePath, args);
 
                     // As C# can't use octal, the octal literal 666 (rw-Permission) is here converted to decimal (438)
-                    await sync.PushAsync(stream, remoteFilePath, UnixFileStatus.DefaultFileMode, File.GetLastWriteTime(localFilePath), null, cancellationToken).ConfigureAwait(false);
+                    await sync.PushAsync(stream, remoteFilePath, UnixFileStatus.DefaultFileMode, File.GetLastWriteTime(localFilePath), progress, cancellationToken).ConfigureAwait(false);
                 }
 
                 return remoteFilePath;


### PR DESCRIPTION
Previously, InstallPackageAsync did not forward the progress reporter to PushAsync, 
causing only 0% and 100% events during the Uploading phase. 
Now, progress updates are correctly propagated for granular feedback during package installation.

See issue #126 